### PR TITLE
fix build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "jsx": "react",
     "declaration": true,
     /* Strict Type-Checking Options */
+    "skipLibCheck": true,
     "strict": true /* Enable all strict type-checking options. */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
   },
   "exclude": ["example", "dist"],
   "include": ["src"]


### PR DESCRIPTION
Fix npm install issue. 
it happens due to `@types/node` and `@types/react-native` having conflicting types which are causing the error.

When running `npm install`
```
Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon: 
> https://opencollective.com/core-js 
> https://www.patreon.com/zloirock 

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)


> react-native-macos@0.62.15 postinstall /...............clipboard/node_modules/react-native-macos
> node scripts/postInstall.js


> @react-native-clipboard/clipboard@1.8.4 prepare /............./clipboard
> yarn build

yarn run v1.22.15
$ tsc
node_modules/@types/node/globals.d.ts:47:11 - error TS2300: Duplicate identifier 'AbortController'.

47 interface AbortController {
             ~~~~~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:389:15
    389 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/@types/node/globals.d.ts:60:11 - error TS2300: Duplicate identifier 'AbortSignal'.

60 interface AbortSignal {
             ~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:376:15
    376 declare class AbortSignal {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/@types/node/globals.d.ts:67:13 - error TS2300: Duplicate identifier 'AbortController'.

67 declare var AbortController: {
               ~~~~~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:389:15
    389 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/@types/node/globals.d.ts:72:13 - error TS2300: Duplicate identifier 'AbortSignal'.

72 declare var AbortSignal: {
               ~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:376:15
    376 declare class AbortSignal {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/@types/react-native/globals.d.ts:376:15 - error TS2300: Duplicate identifier 'AbortSignal'.

376 declare class AbortSignal {
                  ~~~~~~~~~~~

  node_modules/@types/node/globals.d.ts:60:11
    60 interface AbortSignal {
                 ~~~~~~~~~~~
    'AbortSignal' was also declared here.
  node_modules/@types/node/globals.d.ts:72:13
    72 declare var AbortSignal: {
                   ~~~~~~~~~~~
    and here.

node_modules/@types/react-native/globals.d.ts:389:15 - error TS2300: Duplicate identifier 'AbortController'.

389 declare class AbortController {
                  ~~~~~~~~~~~~~~~

  node_modules/@types/node/globals.d.ts:47:11
    47 interface AbortController {
                 ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.
  node_modules/@types/node/globals.d.ts:67:13
    67 declare var AbortController: {
                   ~~~~~~~~~~~~~~~
    and here.


Found 6 errors.
```